### PR TITLE
Fix packaging

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/migrations/harfbuzz11.yaml
+++ b/.ci_support/migrations/harfbuzz11.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for harfbuzz 11
-  kind: version
-  migration_number: 1
-harfbuzz:
-- '11'
-migrator_ts: 1743088015.7278726

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
@@ -29,7 +29,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/win_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/win_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/win_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.ci_support/win_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/win_64_numpy2python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ fftw:
 freetype:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libjpeg_turbo:
 - '3'
 libode:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export RUST_BACKTRACE=1
 
 cat >~/.condarc <<CONDARC
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  "rattler-build=0.40" conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,7 +20,6 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
-export RUST_BACKTRACE=1
 
 cat >~/.condarc <<CONDARC
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  "rattler-build=0.40" conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -45,7 +45,6 @@ for %%l in (^
 :: Build panda using special panda3d tool
 :: Use vs2019 compiler (msvc_version 14.2)
 %PYTHON% makepanda/makepanda.py ^
-    --wheel ^
     --threads=%CPU_COUNT% ^
     --outputdir=build ^
     --everything ^
@@ -55,14 +54,13 @@ for %%l in (^
     %ADDITIONAL_OPTIONS%
 if errorlevel 1 exit 1
 
-:: Install wheel which install python
-:: On Windows the wildcard must be unfold manually
-for %%f in (panda3d*.whl) do (
-    %PYTHON% -m pip install %%f -vv
-)
-if errorlevel 1 exit 1
-
 cd build
+
+:: Install site-packages
+mkdir %SP_DIR%\panda3d
+robocopy panda3d %SP_DIR%\panda3d /E >nul
+mkdir %SP_DIR%\direct
+robocopy direct %SP_DIR%\direct /E >nul
 
 :: Install bin & lib in sysroot-folder
 robocopy bin %LIBRARY_BIN% /E >nul

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -52,6 +52,7 @@ do
     export ADDITIONAL_OPTIONS=--no-$l\ $ADDITIONAL_OPTIONS
 done
 
+
 # Build panda using special panda3d tool
 $PYTHON makepanda/makepanda.py \
     --threads=${CPU_COUNT} \
@@ -63,22 +64,25 @@ $PYTHON makepanda/makepanda.py \
 # Manual installation of other elements
 cd build
 
-# Install site-packages
-cp -r panda3d/ $SP_DIR
-cp -r direct/ $SP_DIR
-
 # Fix install-name on darwin
-if [[ $target_platform == "osx-*" ]]; then
-  for file in lib/*.dylib bin/*; do
+if [[ "$target_platform" == osx-* ]]; then
+  for file in lib/*.dylib bin/* panda3d/*.so direct/*.so; do
+    if [[ $file == *".dylib" ]]; then
+      install_name_tool -id @rpath/$(basename "$file") $file
+    fi
     otool -L $file | tail -n +2 | tr -d '\t' | cut -d ' ' -f 1 > tmp_otool.txt
     while read linked; do
       if [[ $linked == "@loader_path/../lib"* ]]; then
         new_linked=$(echo "$linked" | sed "s/@loader_path\/..\/lib/@rpath/")
-        install_name_tool $linked $new_linked $file
+        install_name_tool -change $linked $new_linked $file
       fi
     done < tmp_otool.txt
   done
 fi
+
+# Install site-packages
+cp -r panda3d $SP_DIR
+cp -r direct $SP_DIR
 
 # Install bin
 cp -r bin/* $PREFIX/bin

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -54,18 +54,34 @@ done
 
 # Build panda using special panda3d tool
 $PYTHON makepanda/makepanda.py \
-    --wheel \
     --threads=${CPU_COUNT} \
     --outputdir=build \
     --everything \
     --verbose \
     $ADDITIONAL_OPTIONS
 
-# Install wheel which install python site-package and binaries
-$PYTHON -m pip install panda3d*.whl -vv
-
 # Manual installation of other elements
 cd build
+
+# Install site-packages
+cp -r panda3d/ $SP_DIR
+cp -r direct/ $SP_DIR
+
+# Fix install-name on darwin
+if [[ $target_platform == "osx-*" ]]; then
+  for file in lib/*.dylib bin/*; do
+    otool -L $file | tail -n +2 | tr -d '\t' | cut -d ' ' -f 1 > tmp_otool.txt
+    while read linked; do
+      if [[ $linked == "@loader_path/../lib"* ]]; then
+        new_linked=$(echo "$linked" | sed "s/@loader_path\/..\/lib/@rpath/")
+        install_name_tool $linked $new_linked $file
+      fi
+    done < tmp_otool.txt
+  done
+fi
+
+# Install bin
+cp -r bin/* $PREFIX/bin
 
 # Install lib
 mkdir $PREFIX/lib || true

--- a/recipe/patches/0001-redirect-3rd-party-dir-to-conda-fix-lib-paths.patch
+++ b/recipe/patches/0001-redirect-3rd-party-dir-to-conda-fix-lib-paths.patch
@@ -294,6 +294,4 @@ index 74a4307a29..336d776295 100644
  OPTIMIZE = "3"
  VERBOSE = False
  LINK_ALL_STATIC = False
--- 
-2.40.1.windows.1
 

--- a/recipe/patches/0002-use-non-static-mimalloc.patch
+++ b/recipe/patches/0002-use-non-static-mimalloc.patch
@@ -20,6 +20,5 @@ index 06cf41da5d..3e2a92518f 100755
      if (PkgSkip("OPENSSL")==0):
          if os.path.isfile(GetThirdpartyDir() + "lib/libpandassl.lib"):
              LibName("OPENSSL", GetThirdpartyDir() + "lib/libpandassl.lib")
--- 
-2.40.1.windows.1
+
 

--- a/recipe/patches/Use-Win32-native-calls-for-atomic-also-with-clang-cl.patch
+++ b/recipe/patches/Use-Win32-native-calls-for-atomic-also-with-clang-cl.patch
@@ -20,6 +20,5 @@ index 804224e5c3..014c4c4445 100644
  // GCC 4.7 and above has built-in __atomic functions for atomic operations.
  // Clang 3.0 and above also supports them.
  
--- 
-2.34.1
+
 

--- a/recipe/patches/Use-Win32-native-calls-for-atomic-also-with-clang-cl.patch
+++ b/recipe/patches/Use-Win32-native-calls-for-atomic-also-with-clang-cl.patch
@@ -1,0 +1,25 @@
+From d79ff54f4d8a3526fcd85219a358dfecd1c49153 Mon Sep 17 00:00:00 2001
+From: Olivier Roussel <olivier.roussel@inria.fr>
+Date: Mon, 5 May 2025 18:02:49 +0200
+Subject: [PATCH] Use Win32 native calls for atomic also with clang-cl
+
+---
+ dtool/src/dtoolbase/atomicAdjust.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dtool/src/dtoolbase/atomicAdjust.h b/dtool/src/dtoolbase/atomicAdjust.h
+index 804224e5c3..014c4c4445 100644
+--- a/dtool/src/dtoolbase/atomicAdjust.h
++++ b/dtool/src/dtoolbase/atomicAdjust.h
+@@ -30,7 +30,7 @@ struct AtomicAdjust {
+ #include "atomicAdjustDummyImpl.h"
+ typedef AtomicAdjustDummyImpl AtomicAdjust;
+ 
+-#elif (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) || (defined(__clang__) && (__clang_major__ >= 3))
++#elif (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))) || (defined(__clang__) && (__clang_major__ >= 3) && !defined(WIN32_VC) )
+ // GCC 4.7 and above has built-in __atomic functions for atomic operations.
+ // Clang 3.0 and above also supports them.
+ 
+-- 
+2.34.1
+

--- a/recipe/patches/fix-makepanda-to-use-custom-3rd-party-libs-for-conda.patch
+++ b/recipe/patches/fix-makepanda-to-use-custom-3rd-party-libs-for-conda.patch
@@ -43,6 +43,5 @@ index 74a4307a29..49db4212bc 100644
          sdkdir = GetThirdpartyBase() + "/win-python"
  
          if sys.version_info >= (3, 0):
--- 
-2.40.1.windows.1
+
 

--- a/recipe/patches/fix-model-path-in-config.prc-template.patch
+++ b/recipe/patches/fix-model-path-in-config.prc-template.patch
@@ -22,6 +22,5 @@ index e262da5bf0..87b1867e73 100644
  
  # This enable the automatic creation of a TK window when running
  # Direct.
--- 
-2.34.1
+
 

--- a/recipe/patches/fix-model-path-in-config.prc-template.patch
+++ b/recipe/patches/fix-model-path-in-config.prc-template.patch
@@ -1,0 +1,27 @@
+From c71d98815a927f27ef5c17a15be193f67e3c120a Mon Sep 17 00:00:00 2001
+From: Olivier Roussel <olivier.roussel@inria.fr>
+Date: Tue, 25 Mar 2025 17:05:42 +0100
+Subject: [PATCH] fix model path in config.prc template
+
+---
+ makepanda/config.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/makepanda/config.in b/makepanda/config.in
+index e262da5bf0..87b1867e73 100644
+--- a/makepanda/config.in
++++ b/makepanda/config.in
+@@ -61,8 +61,8 @@ default-directnotify-level warning
+ # particular Config.prc file.
+ 
+ model-path    $MAIN_DIR
+-model-path    $THIS_PRC_DIR/..
+-model-path    $THIS_PRC_DIR/../models
++model-path    $THIS_PRC_DIR/../../share/panda3d
++model-path    $THIS_PRC_DIR/../../share/panda3d/models
+ 
+ # This enable the automatic creation of a TK window when running
+ # Direct.
+-- 
+2.34.1
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -38,11 +38,14 @@ build:
         - lib/python*/site-packages/deploy_libs/**/*
         - lib/python*/site-packages/panda3d_tools/**/*
         - lib/python*/site-packages/pandac/**/*
+        - lib/python*/site-packages/**/__pycache__
       - if: win
         then:
         - Lib/site-packages/deploy_libs/**/*
         - Lib/site-packages/panda3d_tools/**/*
         - Lib/site-packages/pandac/**/*
+        - Lib/site-packages/**/__pycache__
+        - Library/**/*.pdb
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: panda3d
   version: 1.10.15
-  build_num: 0
+  build_num: 1
 
 package:
   name: ${{ name }}
@@ -20,6 +20,9 @@ source:
       then:
         - patches/0001-redirect-3rd-party-dir-to-conda-fix-lib-paths.patch
         - patches/0002-use-non-static-mimalloc.patch
+
+    # fix the ressource model directory to installed on in <prefix>/share/panda3d
+    - fix-model-path-in-config.prc-template.patch
 
 build:
   number: ${{ build_num }}
@@ -160,6 +163,17 @@ tests:
       imports:
         - panda3d
         - direct
+  - files:
+      recipe:
+        - test/
+    requirements:
+      run:
+        - ${{ stdlib('c') }}
+        - ${{ compiler('cxx') }}
+        - cmake
+        - ninja
+        - eigen
+    script: run_test
 
 about:
   homepage: https://www.panda3d.org/

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,7 +22,7 @@ source:
         - patches/0002-use-non-static-mimalloc.patch
 
     # fix the ressource model directory to installed on in <prefix>/share/panda3d
-    - fix-model-path-in-config.prc-template.patch
+    - patches/fix-model-path-in-config.prc-template.patch
 
     # When compiling on win32, different atomic types are used if using MSVC or clang-cl compilers.
     # This causes linking errors due to different symbols in lib files when trying to link

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,14 +12,14 @@ source:
     sha256: dfe93123a73570377ef77c2a1b6ecff46c9b507750d8bedde07f9244cc1e741e
 
     patches:
-      - if: win or osx
-        then:
-          - patches/fix-makepanda-to-use-custom-3rd-party-libs-for-conda.patch
+    - if: win or osx
+      then:
+        - patches/fix-makepanda-to-use-custom-3rd-party-libs-for-conda.patch
 
-      - if: win
-        then:
-          - patches/0001-redirect-3rd-party-dir-to-conda-fix-lib-paths.patch
-          - patches/0002-use-non-static-mimalloc.patch
+    - if: win
+      then:
+        - patches/0001-redirect-3rd-party-dir-to-conda-fix-lib-paths.patch
+        - patches/0002-use-non-static-mimalloc.patch
 
     # fix the ressource model directory to installed on in <prefix>/share/panda3d
     - fix-model-path-in-config.prc-template.patch

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -24,6 +24,13 @@ source:
     # fix the ressource model directory to installed on in <prefix>/share/panda3d
     - fix-model-path-in-config.prc-template.patch
 
+    # When compiling on win32, different atomic types are used if using MSVC or clang-cl compilers.
+    # This causes linking errors due to different symbols in lib files when trying to link
+    # with this panda3d conda package as a 3rd party library with clang-cl, whereas the conda
+    # package has been built with MSVC. This fix forces clang-cl to use win32 native atomic types
+    # as it is done with MSVC.
+    - patches/Use-Win32-native-calls-for-atomic-also-with-clang-cl.patch
+
 build:
   number: ${{ build_num }}
   dynamic_linking:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,12 @@
+setlocal EnableDelayedExpansion
+
+cd test
+mkdir build
+
+:: Compile basic example that links panda3d
+cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+mkdir -p test/build
+cmake -S test -B test/build -G "Ninja"
+cmake --build test/build --target all

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.15)
+
+# The entire purpose of this project is to test a correct installation of
+# panda3d, by linking a simple executable against it.
+project(Panda3dTestConda)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+
+find_package(Panda3d REQUIRED)
+find_package(Eigen3 REQUIRED CONFIG)
+
+add_executable(TestExe test.cpp)
+target_link_libraries(TestExe PUBLIC 
+  Eigen3::Eigen 
+  panda3d::panda 
+  panda3d::p3dtoolconfig
+  panda3d::p3dtool
+  panda3d::p3framework)

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -11,8 +11,9 @@ find_package(Eigen3 REQUIRED CONFIG)
 
 add_executable(TestExe test.cpp)
 target_link_libraries(TestExe PUBLIC 
-  Eigen3::Eigen 
-  panda3d::panda 
+  Eigen3::Eigen
+  panda3d::panda
+  panda3d::pandaexpress
   panda3d::p3dtoolconfig
   panda3d::p3dtool
   panda3d::p3framework)

--- a/recipe/test/FindPanda3d.cmake
+++ b/recipe/test/FindPanda3d.cmake
@@ -1,0 +1,60 @@
+# Find the panda3d headers and libraries
+#
+# Defines:
+#   Panda3d_FOUND : True if panda3d (all libraries) is found
+#   Panda3d_INCLUDE_DIRS
+#   Panda3D_LIBRARIES
+#
+# Provides targets 
+#   panda3d::panda
+#   panda3d::p3framework
+#   panda3d::pandaexpress
+#   panda3d::p3dtoolconfig
+#   panda3d::p3dtool
+#   panda3d::p3direct
+#   panda3d::pandaegg
+#   panda3d::p3ffmpeg
+#   panda3d::p3interrogatedb
+#   panda3d::p3tinydisplay
+#   panda3d::p3vision
+#   panda3d::pandaai
+#   panda3d::pandafx
+#   panda3d::pandaphysics
+#   panda3d::pandaskel
+
+set(PANDA3D_LIBS
+  panda p3framework pandaexpress
+  p3dtoolconfig p3dtool p3direct
+  pandaegg p3ffmpeg p3interrogatedb p3tinydisplay p3vision
+  pandaai pandafx pandaphysics pandaskel
+)
+
+find_path(Panda3d_INCLUDE_DIRS panda3d/panda.h PATH_SUFFIXES include)
+
+mark_as_advanced(Panda3d_INCLUDE_DIRS)
+
+# Fetch all libraries
+set(Panda3D_LIBRARIES "")
+set(ALL_LIBS_FOUND TRUE)
+foreach(lib_name ${PANDA3D_LIBS})
+  find_library(Panda3d_${lib_name}_LIBRARY NAMES ${lib_name} PATH_SUFFIXES lib)
+  if(NOT Panda3d_${lib_name}_LIBRARY)
+    set(ALL_LIBS_FOUND FALSE)
+  else()
+    list(APPEND Panda3D_LIBRARIES ${Panda3d_${lib_name}_LIBRARY})
+    add_library(panda3d::${lib_name} SHARED IMPORTED)
+    set_property(TARGET panda3d::${lib_name} PROPERTY IMPORTED_LOCATION "${Panda3d_${lib_name}_LIBRARY}")
+    if(WIN32)
+      set_property(TARGET panda3d::${lib_name} PROPERTY IMPORTED_IMPLIB "${Panda3d_${lib_name}_LIBRARY}")
+    endif()
+    set_property(TARGET panda3d::${lib_name} PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${Panda3d_INCLUDE_DIRS}")
+  endif()
+
+  mark_as_advanced(Panda3d_${lib_name}_LIBRARY)
+endforeach()
+
+
+include(FindPackageHandleStandardArgs)
+# Handle the QUIETLY and REQUIRED arguments and set the Panda3D_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Panda3d DEFAULT_MSG ALL_LIBS_FOUND Panda3d_INCLUDE_DIRS)

--- a/recipe/test/test.cpp
+++ b/recipe/test/test.cpp
@@ -1,0 +1,31 @@
+// Include all the stuff
+#include <panda3d/pandaFramework.h>
+#include <panda3d/pandaSystem.h>
+
+int main(int argc, char *argv[]) {
+  // Open the framework
+  PandaFramework framework;
+  framework.open_framework(argc, argv);
+  // Set a nice title
+  framework.set_window_title("Hello World!");
+  // Open it!
+  WindowFramework *window = framework.open_window();
+
+  // Check whether the window is loaded correctly
+  if (window != nullptr) {
+    nout << "Opened the window successfully!\n";
+
+    window->enable_keyboard(); // Enable keyboard detection
+    window->setup_trackball(); // Enable default camera movement
+
+    // Put here your own code, such as the loading of your models
+
+    // Do the main loop
+    framework.main_loop();
+  } else {
+    nout << "Could not load the window!\n";
+  }
+  // Close the framework
+  framework.close_framework();
+  return (0);
+}

--- a/recipe/test/test.cpp
+++ b/recipe/test/test.cpp
@@ -25,6 +25,14 @@ int main(int argc, char *argv[]) {
   } else {
     nout << "Could not load the window!\n";
   }
+
+  // Check linkage errors on win32 when linking with clang-cl this executable
+  // using a panda3d conda package built with MSVC
+  GraphicsOutput *windowOutput = window->get_graphics_output();
+  GraphicsStateGuardian* gsg = windowOutput->get_gsg();
+  // this call would break linkage due to different symbols for ConfigFlags::_global_modified
+  auto dummy2 = gsg->get_copy_texture_inverted();
+
   // Close the framework
   framework.close_framework();
   return (0);


### PR DESCRIPTION
This PR fixes the following bugs:
- Duplicated libraries installation in lib directory and along python site-packages (removed installation from pip)
- Invalid rpath on macOS
- Invalid resource directory
- Inconsistent symbols on windows between compilation using MSVC and clang-cl (cause linkage error if trying to compile using panda3d conda package as 3rd party library with clang-cl whereas the panda3d conda package was build with MSVC, and reciprocally).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
